### PR TITLE
Prefer CI merge strategy when syncing generated artifacts

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -51,8 +51,13 @@ jobs:
           if ! git diff-index --quiet HEAD; then
             git commit -m "Update content [skip ci]"
           fi
-          git pull --no-rebase origin main
-          git push origin main || echo "No changes to push"
+          git fetch origin main
+          if ! git merge --no-edit -s ours origin/main; then
+            git merge --abort || true
+            echo "Unable to merge changes from origin/main even after preferring ours."
+            exit 1
+          fi
+          git push origin HEAD:main || echo "No changes to push"
 
   build-and-deploy:
     name: Build and Deploy Jekyll Site
@@ -225,5 +230,10 @@ jobs:
           if ! git diff-index --quiet HEAD; then
             git commit -m "Update content [skip ci]"
           fi
-          git pull --no-rebase origin main
-          git push origin main || echo "No changes to push"
+          git fetch origin main
+          if ! git merge --no-edit -s ours origin/main; then
+            git merge --abort || true
+            echo "Unable to merge changes from origin/main even after preferring ours."
+            exit 1
+          fi
+          git push origin HEAD:main || echo "No changes to push"


### PR DESCRIPTION
## Summary
- update the generated-content commit steps to fetch origin/main before merging
- merge with the `ours` strategy to prefer CI outputs and abort if a conflict still occurs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d9ab41ae30832da318daf8223dfc21