### PR TITLE
Port f4p from Python to PowerShell and update docs to use `f4p.ps1`

### DIFF
--- a/_posts/2025-02-05-f4p.md
+++ b/_posts/2025-02-05-f4p.md
@@ -454,7 +454,7 @@ function Invoke-PathProcessing {
             return
         }
 
-        Invoke-PathProcessing -CurrentPath $itemPath -Depth ($Depth + 1) -InheritedGitignore $allRules -OutputChunks $OutputChunks -Index $Index -TemplateContent $TemplateContent
+        Invoke-PathProcessing -CurrentPath $itemPath -Depth $Depth -InheritedGitignore $allRules -OutputChunks $OutputChunks -Index $Index -TemplateContent $TemplateContent
     }
 }
 

--- a/_posts/2025-02-05-f4p.md
+++ b/_posts/2025-02-05-f4p.md
@@ -450,7 +450,8 @@ function Invoke-PathProcessing {
             return
         }
 
-        if ($Ignore.Count -gt 0 -and ($Ignore | Where-Object { $itemPath -like $_ -or (Split-Path -Path $itemPath -Leaf) -like $_ })) {
+        $itemName = $_.Name
+        if ($Ignore.Count -gt 0 -and $Ignore.Where({ $itemPath -like $_ -or $itemName -like $_ }, 'First')) {
             return
         }
 

--- a/_posts/2025-02-05-f4p.md
+++ b/_posts/2025-02-05-f4p.md
@@ -1,5 +1,5 @@
 ---
-tags: [scripts>python]
+tags: [scripts>powershell]
 info: aberto.
 date: 2025-02-05
 type: post
@@ -12,23 +12,24 @@ title: 'files for prompt (f4p)'
 ## 1. INSTALLATION
 
 ### 1.1 Primary Requirements
-- **click** (command-line interface support)
-- **Optional modules:**
-  - **rarfile** for `.rar` archives
-  - **py7zr** for `.7z` archives
-  - **pathspec** for advanced `.gitignore` matching
-  - **jinja2** for templated output
+- **PowerShell 7+** (`pwsh`)
+- **Optional extractors:**
+  - **7z** for `.7z` archives
+  - **unrar** for `.rar` archives
+- **tar** (usually available on Linux/macOS) for `.tar`, `.gz`, `.bz2` archives
 
-Install everything:
+Validate prerequisites:
 ```bash
-pip install click rarfile py7zr pathspec jinja2
+pwsh --version
+7z --help   # optional
+unrar       # optional
+tar --help
 ```
-Or install only what you need (for example, omit `rarfile` if you don't require `.rar` support).
 
 ### 1.2 Script File Reference
-The provided script is typically named `f4p.py`, so you would run:
+The provided script is typically named `f4p.ps1`, so you would run:
 ```bash
-python f4p.py [OPTIONS] [PATHS...]
+pwsh ./f4p.ps1 [OPTIONS] [PATHS...]
 ```
 
 ---
@@ -37,7 +38,7 @@ python f4p.py [OPTIONS] [PATHS...]
 
 Run the script as follows:
 ```bash
-python f4p.py [OPTIONS] /some/path /another/path
+pwsh ./f4p.ps1 [OPTIONS] /some/path /another/path
 ```
 - The script recursively scans directories and extracts recognized archives:
   - `.zip`, `.rar`, `.7z`, `.tar`, `.gz`, `.bz2`
@@ -51,728 +52,437 @@ python f4p.py [OPTIONS] /some/path /another/path
 
 | Flag/Option         | Type / Default       | Short | Description                                                     |
 |---------------------|----------------------|-------|-----------------------------------------------------------------|
-| `--extension`       | multiple=True / None | `-e`  | Restricts processing to specific extensions (archives & Office docs). |
-| `--include-hidden`  | is_flag=True / False | n/a   | Considers hidden/dot files and directories.                     |
-| `--ignore-gitignore`| is_flag=True / False | n/a   | Ignores `.gitignore` rules in directories.                      |
-| `--ignore`          | multiple=True / None | n/a   | Excludes files matching glob patterns (e.g., `*.log`).            |
-| `--output`          | file path / None     | `-o`  | Writes output to the specified file instead of stdout.          |
-| `--xml`             | is_flag=True / False | n/a   | Outputs content in an XML-like structure.                       |
-| `--template-file`   | file path / None     | `-t`  | Uses a Jinja2 template for custom formatting (requires jinja2).   |
-| `--max-depth`       | int / 5              | `-d`  | Limits recursion depth for nested archives (default: 5).          |
+| `-Extension`       | string[] / empty       | `-e`  | Restricts processing to specific extensions (archives & Office docs). |
+| `-IncludeHidden`  | switch / False         | n/a   | Includes hidden/dot files and directories.                     |
+| `-IgnoreGitignore`| switch / False         | n/a   | Ignores `.gitignore` rules in directories.                      |
+| `-Ignore`          | string[] / empty       | n/a   | Excludes files matching glob patterns (e.g., `*.log`).            |
+| `-Output`          | file path / None       | `-o`  | Writes output to the specified file instead of stdout.          |
+| `-Xml`             | switch / False         | n/a   | Outputs content in an XML-like structure.                       |
+| `-TemplateFile`   | file path / None       | `-t`  | Uses token replacement for custom formatting (`{{ path }}`, `{{ content }}`, `{{ index }}`).   |
+| `-MaxDepth`       | int / 5                | `-d`  | Limits recursion depth for nested archives (default: 5).          |
 
 ---
 
 ## 4. FILE & ENCODING LOGIC
 
-1. **Multiple Encoding Attempts:**  
-   - Tries `utf-8` first, then `latin-1`.  
+1. **Multiple Encoding Attempts:**
+   - Tries `utf-8` first, then `latin-1`.
    - If both fail, the file's content is omitted (with a warning logged).
 
-2. **Archive & Office Document Extraction:**  
-   - `.rar` extraction requires `rarfile`, and `.7z` extraction requires `py7zr`.  
-   - Office documents (OOXML/ODF) are processed as `.zip` archives.  
-   - Extraction is performed safely to prevent path traversal vulnerabilities.
+2. **Archive & Office Document Extraction:**
+   - `.rar` extraction uses `unrar` when available, and `.7z` extraction uses `7z` when available.
+   - Office documents (OOXML/ODF) are processed as `.zip` archives.
+   - Extraction occurs in temporary folders and unsupported extractors emit warnings.
 
 ---
 
 ## 5. IGNORING LOGIC
 
-1. **.gitignore / pathspec:**  
-   - When `pathspec` is installed, advanced `.gitignore` rules apply.  
-   - Otherwise, a simpler fnmatch approach is used.
+1. **.gitignore Handling:**
+   - The script reads `.gitignore` lines and applies wildcard matching (`-like`) against file names and paths.
+   - This is a pragmatic matcher and not a full `gitwildmatch` implementation.
 
-2. **Hidden Files:**  
-   - Hidden items are skipped by default (unless `--include-hidden` is used).
+2. **Hidden Files:**
+   - Hidden items are skipped by default (unless `-IncludeHidden` is used).
 
-3. **Additional Patterns:**  
-   - Use `--ignore` to exclude files (e.g., `--ignore="*.log"` or `--ignore="*_backup.*"`).
+3. **Additional Patterns:**
+   - Use `-Ignore` to exclude files (e.g., `-Ignore "*.log"` or `-Ignore "*_backup.*"`).
 
 ---
 
 ## 6. OUTPUT FORMATS
 
-1. **Plain Text (Default):**  
+1. **Plain Text (Default):**
    - Prints each file’s path, followed by a separator and the file content.
 
-2. **XML-like (`--xml`):**  
+2. **XML-like (`-Xml`):**
    - Wraps the content within `<section>...</section>` elements.
 
-3. **Jinja2 Templates (`-t`/`--template-file`):**  
-   - Applies a provided `.j2` template to format each file's content.
+3. **Template File (`-t`/`-TemplateFile`):**
+   - Applies token replacement in a text template to format each file's content.
 
 ---
 
 ## 7. EXAMPLES
 
-1. **Restrict to `.py` & `.md` and ignore `*.log`:**
+1. **Restrict to `.ps1` & `.md` and ignore `*.log`:**
    ```bash
-   python f4p.py -e .py -e .md --ignore="*.log" /path/to/process
+   pwsh ./f4p.ps1 -Extension .ps1 -Extension .md -Ignore "*.log" /path/to/process
    ```
 
 2. **Process hidden files, disable `.gitignore`, and output to a file:**
    ```bash
-   python f4p.py --include-hidden --ignore-gitignore -o out.txt /some/path
+   pwsh ./f4p.ps1 -IncludeHidden -IgnoreGitignore -Output out.txt /some/path
    ```
 
 3. **Output as XML and limit recursion to 3 levels:**
    ```bash
-   python f4p.py --xml --max-depth=3 /path/to/archives
+   pwsh ./f4p.ps1 -Xml -MaxDepth 3 /path/to/archives
    ```
 
-4. **Use a Jinja2 template:**
+4. **Use a template file:**
    ```bash
-   python f4p.py --template-file=custom_template.j2 /path/to/files
+   pwsh ./f4p.ps1 -TemplateFile custom_template.txt /path/to/files
    ```
 
 5. **Process multiple paths:**
    ```bash
-   python f4p.py /first/path /second/path
+   pwsh ./f4p.ps1 /first/path /second/path
    ```
 
 ---
 
-## 8. Jinja2 EXAMPLES
+## 8. TEMPLATE EXAMPLES
 
 When invoking:
 ```bash
-python f4p.py -t my_template.j2 [PATHS...]
+pwsh ./f4p.ps1 -TemplateFile my_template.txt [PATHS...]
 ```
-the template receives:
-- `{{ path }}`: the file's path
-- `{{ content }}`: the file's text content
-- `{{ index }}`: a numeric counter for labeling
+the template supports direct token replacement for:
+- `{{ path }}`: file path
+- `{{ content }}`: full file content
+- `{{ index }}`: running index
 
-### Example Templates
+### Valid Token-Based Examples
 
-1. **Minimal Example: Plain-Text Highlight**  
-   *File: minimal_example.j2*
-   ```jinja
-   
-   File #{{ index }}: {{ path }}
-   ----------------------------
-   {{ content }}
-   ----------------------------
-   
-   ```
-   *Rationale:* Displays the file path and content with a simple separator.
+1. **Minimal text wrapper** (`minimal_example.txt`)
+```text
+File #{{ index }}: {{ path }}
+----------------------------
+{{ content }}
+----------------------------
+```
 
-2. **Numbered Lines Use Case**  
-   *File: numbered_lines.j2*
-   ```jinja
-   
-   File: {{ path }} (Index: {{ index }})
-   ======================================
-   {% set lines = content.split('\n') %}
-   {% for loop_index, line in lines | enumerate(start=1) %}
-   {{ loop_index }}: {{ line }}
-   {% endfor %}
-   ======================================
-   
-   ```
-   *Rationale:* Enumerates each line, useful for line-by-line reference.
+2. **Markdown snippet** (`markdown_snippet.txt`)
+```text
+### File #{{ index }}: {{ path }}
 
-3. **HTML Output for Browser Rendering**  
-   *File: html_output.j2*
-   ```jinja
-   
-   <html>
-     <head>
-       <title>File {{ index }}</title>
-     </head>
-     <body>
-       <h2>File Path: {{ path }}</h2>
-       <p><strong>Index:</strong> {{ index }}</p>
-       <hr />
-       <pre>
-   {{ content }}
-       </pre>
-     </body>
-   </html>
-   
-   ```
-   *Rationale:* Formats the file content into a simple HTML page.
+~~~text
+{{ content }}
+~~~
+```
 
-4. **Markdown Code Snippet**  
-   *File: markdown_snippet.j2*
-   ```jinja
-   
-   ### File #{{ index }}: {{ path }}
-   
-   ```
-   {{ content }}
-   ```
-   
-   ```
-   *Rationale:* Ideal for embedding code or text in a Markdown document.
+3. **JSON-style envelope** (`json_envelope.txt`)
+```text
+{
+  "index": "{{ index }}",
+  "path": "{{ path }}",
+  "content": "{{ content }}"
+}
+```
 
-5. **Summarized Headings Template**  
-   *File: summarized_headings.j2*
-   ```jinja
-   
-   ["FILE #{{ index }}"] {{ path }}
-   ---------------------------------
-   {% set first_lines = content.split('\n')[:3] %}
-   {% for line in first_lines %}
-   {{ line }}
-   {% endfor %}
-   ---------------------------------
-   (... Content Truncated ...)
-   
-   ```
-   *Rationale:* Shows only the first few lines to save space.
+4. **HTML wrapper** (`html_output.txt`)
+```text
+<html>
+  <body>
+    <h2>{{ path }}</h2>
+    <pre>{{ content }}</pre>
+  </body>
+</html>
+```
 
-6. **JSON-Inspired Output Template**  
-   *File: json_inspired.j2*
-   ```jinja
-   
-   {
-     "index": {{ index }},
-     "path": "{{ path | replace('\\', '\\\\') }}",
-     "content_lines": [
-   {% set lines = content.split('\n') %}
-   {% for line in lines %}
-       "{{ line | replace('"','\\"') }}"{{ "," if not loop.last else "" }}
-   {% endfor %}
-     ]
-   }
-   
-   ```
-   *Rationale:* Outputs the file data in a JSON-like structure.
-
-7. **Columnar Key-Value Template**  
-   *File: columnar_kv.j2*
-   ```jinja
-   
-   ===============
-   File #{{ index }}
-   ===============
-   Path: {{ path }}
-   ---------------
-   {% for key, val in {
-      'Characters': content|length,
-      'Lines': content.split('\n')|length,
-      'First Line': content.split('\n')[0] if content else ''
-   }.items() %}
-   {{ key }}: {{ val }}
-   {% endfor %}
-   ---------------
-   {{ content }}
-   
-   ```
-   *Rationale:* Displays statistics followed by the file content.
-
-8. **Interactive-Like Script Template**  
-   *File: interactive_prompt.j2*
-   ```jinja
-   
-   === File #{{ index }} ===
-   LOAD FILE: {{ path }}
-   
-   RUN COMMANDS:
-   1) SomeProcess --file "{{ path }}"
-   2) AnotherProcess --analyze "{{ path }}"
-   3) (Optional) Check content below:
-   
-   {{ content }}
-   =================
-   
-   ```
-   *Rationale:* Provides a stylized “script” output with follow-up commands.
-
-9. **Task-List / To-Do Style Template**  
-   *File: task_list.j2*
-   ```jinja
-   
-   ## File #{{ index }}: {{ path }}
-   
-   - [ ] Review lines for errors
-   - [ ] Extract useful references
-   - [ ] Create summary
-   - [ ] Mark for final review
-   
-   Content:
-   {{ content }}
-   
-   ```
-   *Rationale:* Produces a checklist along with the file content.
-
-10. **Blockquote Slicer Template**  
-    *File: blockquote_slicer.j2*
-    ```jinja
-    
-    > **File #{{ index }}**: {{ path }}
-    {% for i, line in content.split('\n') | enumerate %}
-    > {{ "%02d" | format(i+1) }} {{ line }}
-    {% endfor %}
-    
-    ```
-    *Rationale:* Converts each line into a blockquote with a line number.
-
-11. **Content by Word Count Buckets**  
-    *File: word_bucket.j2*
-    ```jinja
-    
-    ## File #{{ index }}: {{ path }}
-    
-    {% set words = content.split() %}
-    {% if words|length < 30 %}
-    (SHORT FILE)
-    {{ content }}
-    {% elif words|length < 100 %}
-    (MEDIUM FILE)
-    ---BEGIN---
-    {{ content }}
-    ---END-----
-    {% else %}
-    (LONG FILE - WORD COUNT: {{ words|length }})
-    [Preview: First 100 words]
-    {{ words[:100]|join(' ') }}
-    [... shortened ...]
-    {% endif %}
-    
-    ```
-    *Rationale:* Adjusts output based on the file's length.
-
-12. **Script-Inlining Template (Code + Comments)**  
-    *File: inline_script.j2*
-    ```jinja
-    
-    ### SCRIPT SNIPPET (INDEX: {{ index }})
-    # File Path: {{ path }}
-    
-    cat <<'EOF' > output_file_{{ index }}.txt
-    {{ content }}
-    EOF
-    
-    # Explanation:
-    # Writes the file content into "output_file_{{ index }}.txt" using a here-document.
-    
-    ```
-    *Rationale:* Useful for recreating file content on another system.
-
-13. **Directory Tree Logging Template**  
-    *File: directory_tree.j2*
-    ```jinja
-    
-    [FILE ENTRY #{{ index }}]
-    PATH: {{ path }}
-    DIR OR FILE: {% if content == '' and '.' not in path.split('/')[-1] %} (Possibly a directory or empty file) {% else %} (File with content) {% endif %}
-    
-    ========= CONTENT START =========
-    {{ content }}
-    ========= CONTENT END ===========
-    
-    ```
-    *Rationale:* Distinguishes between empty directories and files with content.
-
-14. **Quick Data Stats with Regex (Custom Filters)**  
-    *File: quick_regex_stats.j2*
-    ```jinja
-    
-    {% set lines = content.split('\n') %}
-    {% set import_lines = lines | select("match", "^(import|from) ") | list %}
-    {% set todo_lines = lines | select("match", ".*TODO.*") | list %}
-    
-    File #{{ index }}: {{ path }}
-    ============================
-    TOTAL LINES: {{ lines|length }}
-    IMPORT STATEMENTS: {{ import_lines|length }}
-    TODO MARKERS: {{ todo_lines|length }}
-    
-    -- EXCERPT (first 5 lines) --
-    {% for l in lines[:5] %}
-    {{ l }}
-    {% endfor %}
-    ----------------------------
-    
-    ```
-    *Rationale:* Analyzes text (e.g., counting “import” or “TODO” occurrences).
+> Note: this implementation does **not** execute Jinja logic (`{% ... %}` / filters / loops).
+> It only performs literal token replacement.
 
 ---
 
 ## 9. FURTHER NOTES
 
-- Ensure you have installed all required modules (e.g., `rarfile`, `py7zr`) for handling specific archive types.
+- Ensure optional external extractors (`7z`, `unrar`) are installed if you need `.7z`/`.rar` support.
 - The script processes `.docx`, `.pptx`, `.xlsx`, `.odt`, `.ods`, and `.odp` as archives.
 - Legacy MS Office formats (such as `.doc`, `.xls`, `.ppt`) are not supported.
-- Adjust the `--max-depth` parameter when processing heavily nested archives.
+- Adjust the `-MaxDepth` parameter when processing heavily nested archives.
 
-```python
-#!/usr/bin/env python3
+```powershell
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0, ValueFromRemainingArguments = $true)]
+    [string[]]$Paths,
 
-import os
-import sys
-import tempfile
-import shutil
-import zipfile
-import tarfile
-import click
-import logging
-from fnmatch import fnmatch
-from typing import Callable, List, Optional, Tuple
+    [Alias('e')]
+    [string[]]$Extension = @(),
 
-# Attempt to import optional modules
-try:
-    import rarfile
-except ImportError:
-    rarfile = None
+    [switch]$IncludeHidden,
+    [switch]$IgnoreGitignore,
 
-try:
-    import py7zr
-except ImportError:
-    py7zr = None
+    [string[]]$Ignore = @(),
 
-try:
-    import pathspec
-except ImportError:
-    pathspec = None
+    [Alias('o')]
+    [string]$Output,
 
-try:
-    from jinja2 import Environment, FileSystemLoader
-except ImportError:
-    Environment = None
-    FileSystemLoader = None
+    [switch]$Xml,
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    stream=sys.stderr,
+    [Alias('t')]
+    [string]$TemplateFile,
+
+    [Alias('d')]
+    [ValidateRange(0, 64)]
+    [int]$MaxDepth = 5
 )
-logger = logging.getLogger(__name__)
 
-def is_within_directory(directory: str, target: str) -> bool:
-    """
-    Checks if the target path is within the specified directory,
-    helping to avoid path traversal vulnerabilities.
-    """
-    abs_directory = os.path.abspath(directory)
-    abs_target = os.path.abspath(target)
-    return os.path.commonprefix([abs_directory, abs_target]) == abs_directory
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
 
-def safe_extract(tar: tarfile.TarFile, path: str = ".", members=None) -> None:
-    """
-    Safely extract tar contents, preventing directory traversal.
-    """
-    for member in (members or tar.getmembers()):
-        member_path = os.path.join(path, member.name)
-        if not is_within_directory(path, member_path):
-            raise ValueError("Detected path traversal attempt.")
-    tar.extractall(path=path, members=members, filter='fully_trusted')
+$script:ArchiveExtensions = @('.zip', '.rar', '.7z', '.tar', '.gz', '.bz2')
+$script:OfficeExtensions = @('.docx', '.xlsx', '.pptx', '.odt', '.ods', '.odp')
 
-def handle_zip(file_path: str, extract_dir: str) -> bool:
-    """
-    Extracts ZIP archives, handling potential exceptions.
-    """
-    try:
-        with zipfile.ZipFile(file_path, "r") as zf:
-            zf.extractall(extract_dir)
-        return True
-    except zipfile.BadZipFile as e:
-        logger.warning(f"Bad ZIP file {file_path}: {str(e)}")
-        return False
+function Test-HiddenPath {
+    param([Parameter(Mandatory)][string]$Path)
 
-def handle_rar(file_path: str, extract_dir: str) -> bool:
-    """
-    Extracts RAR archives if rarfile is available.
-    """
-    if not rarfile:
-        logger.warning("RAR handling requires 'rarfile' to be installed.")
-        return False
-    try:
-        with rarfile.RarFile(file_path, "r") as rf:
-            rf.extractall(extract_dir)
-        return True
-    except rarfile.Error as e:
-        logger.warning(f"RAR extraction failed: {str(e)}")
-        return False
+    $leaf = Split-Path -Path $Path -Leaf
+    if ($leaf.StartsWith('.')) {
+        return $true
+    }
 
-def handle_7z(file_path: str, extract_dir: str) -> bool:
-    """
-    Extracts 7z archives if py7zr is available.
-    """
-    if not py7zr:
-        logger.warning("7z handling requires 'py7zr' to be installed.")
-        return False
-    try:
-        with py7zr.SevenZipFile(file_path, "r") as sz:
-            sz.extractall(extract_dir)
-        return True
-    except py7zr.exceptions.Bad7zFile as e:
-        logger.warning(f"7z extraction failed: {str(e)}")
-        return False
+    if (Test-Path -LiteralPath $Path) {
+        $item = Get-Item -LiteralPath $Path -Force
+        return (($item.Attributes -band [IO.FileAttributes]::Hidden) -ne 0)
+    }
 
-def handle_tar(file_path: str, extract_dir: str) -> bool:
-    """
-    Extracts TAR archives, using safe_extract to avoid path traversal.
-    """
-    try:
-        with tarfile.open(file_path, "r:*") as tf:
-            safe_extract(tf, extract_dir)
-        return True
-    except tarfile.TarError as e:
-        logger.warning(f"TAR extraction failed: {str(e)}")
-        return False
-
-ARCHIVE_HANDLERS = {
-    ".zip": handle_zip,
-    ".rar": handle_rar,
-    ".7z": handle_7z,
-    ".tar": handle_tar,
-    ".gz": handle_tar,
-    ".bz2": handle_tar,
+    return $false
 }
 
-OFFICE_EXTENSIONS = [".docx", ".xlsx", ".pptx", ".odt", ".ods", ".odp"]
+function Get-GitignoreRules {
+    param([Parameter(Mandatory)][string]$Directory)
 
-def read_gitignore(directory: str) -> List[str]:
-    """
-    Reads lines from .gitignore if present.
-    """
-    path = os.path.join(directory, ".gitignore")
-    if os.path.isfile(path):
-        with open(path, "r", encoding="utf-8") as f:
-            return [line.strip() for line in f if line.strip() and not line.startswith("#")]
-    return []
+    $gitignore = Join-Path -Path $Directory -ChildPath '.gitignore'
+    if (-not (Test-Path -LiteralPath $gitignore)) {
+        return @()
+    }
 
-def should_ignore(path: str, rules: List[str]) -> bool:
-    """
-    Basic fnmatch-based ignoring for files or directories.
-    """
-    base = os.path.basename(path)
-    if os.path.isdir(path):
-        base += "/"
-    return any(fnmatch(base, rule) for rule in rules)
+    return Get-Content -LiteralPath $gitignore -ErrorAction SilentlyContinue |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ -and -not $_.StartsWith('#') }
+}
 
-class GitignoreHandler:
-    """
-    Handles ignoring of files or directories based on .gitignore (via pathspec or fallback).
-    """
-    def __init__(self, directory: str):
-        self.pathspec_spec = None
-        self.fallback_rules = []
-        lines = read_gitignore(directory)
-        if pathspec:
-            self.pathspec_spec = pathspec.PathSpec.from_lines("gitwildmatch", lines)
-        else:
-            self.fallback_rules = lines
-
-    def should_ignore(self, path_to_check: str) -> bool:
-        if self.pathspec_spec:
-            return self.pathspec_spec.match_file(path_to_check)
-        return should_ignore(path_to_check, self.fallback_rules)
-
-class OutputFormatter:
-    """
-    Outputs data in either plain text, XML-like format, or via Jinja2 templates if available.
-    """
-    def __init__(
-        self,
-        writer: Callable[[str], None],
-        xml_mode: bool = False,
-        template_file: Optional[str] = None
-    ):
-        self.writer = writer
-        self.xml_mode = xml_mode
-        self.xml_index = 1
-        self.template_file = template_file
-        self.jinja_env = None
-        if template_file and Environment and FileSystemLoader:
-            template_dir = os.path.dirname(template_file)
-            self.jinja_env = Environment(loader=FileSystemLoader(template_dir))
-
-    def write(self, path: str, content: str) -> None:
-        """
-        Decides the approach (Jinja2/XML/plain text) for output.
-        """
-        if self.jinja_env and self.template_file:
-            try:
-                template_name = os.path.basename(self.template_file)
-                template = self.jinja_env.get_template(template_name)
-                rendered = template.render(path=path, content=content, index=self.xml_index)
-                self.writer(rendered)
-            except Exception as e:
-                logger.warning(f"Jinja2 rendering error: {e}")
-                self._fallback_write(path, content)
-        elif self.xml_mode:
-            self.writer(f'<source>')
-            self.writer(f'{path}')
-            self.writer('</source>')
-            self.writer('<contents>')            
-            for line in content.splitlines():
-                self.writer(f'{line}')
-            self.writer('</contents>')
-            self.xml_index += 1
-        else:
-            self._fallback_write(path, content)
-
-    def _fallback_write(self, path: str, content: str):
-        """
-        Prints content with separators if not using templates or XML.
-        """
-        self.writer(path)
-        self.writer("--")
-        self.writer(content)
-        self.writer("")
-        self.writer("--")
-        self.xml_index += 1
-
-class FileProcessor:
-    """
-    Manages recursion through directories or archives and applies ignoring, formatting, etc.
-    """
-    def __init__(
-        self,
-        extensions: Tuple[str, ...],
-        include_hidden: bool,
-        ignore_gitignore: bool,
-        ignore_patterns: Tuple[str, ...],
-        formatter: OutputFormatter,
-        max_depth: int = 5,
-    ):
-        self.extensions = [ext.lower() for ext in extensions]
-        self.include_hidden = include_hidden
-        self.ignore_gitignore = ignore_gitignore
-        self.ignore_patterns = ignore_patterns
-        self.formatter = formatter
-        self.max_depth = max_depth
-
-    def process_path(self, path: str, depth: int = 0, extra_gitignore_rules: List[str] = None) -> None:
-        if extra_gitignore_rules is None:
-            extra_gitignore_rules = []
-        if depth > self.max_depth:
-            logger.warning(f"Max recursion depth ({self.max_depth}) reached at {path}.")
-            return
-        if os.path.isfile(path):
-            self._handle_file(path, depth)
-        elif os.path.isdir(path):
-            if not self.ignore_gitignore:
-                extra_gitignore_rules.extend(read_gitignore(path))
-            self._handle_directory(path, depth, extra_gitignore_rules)
-
-    def _handle_file(self, path: str, depth: int) -> None:
-        ext = os.path.splitext(path)[1].lower()
-        if ext in ARCHIVE_HANDLERS or ext in OFFICE_EXTENSIONS:
-            self._extract_and_recurse(path, ext, depth)
-        else:
-            self._read_and_output(path)
-
-    def _extract_and_recurse(self, path: str, ext: str, depth: int) -> None:
-        handler_func = ARCHIVE_HANDLERS.get(ext)
-        if ext in OFFICE_EXTENSIONS:
-            # Office documents are ZIP-based archives
-            handler_func = ARCHIVE_HANDLERS[".zip"]
-        if not handler_func:
-            logger.warning(f"No valid handler for extension: {ext}")
-            return
-        with tempfile.TemporaryDirectory() as tmpdir:
-            success = handler_func(path, tmpdir)
-            if success:
-                self.process_path(tmpdir, depth + 1)
-            else:
-                logger.warning(f"Extraction failed for {path}")
-
-    def _read_and_output(self, path: str) -> None:
-        encodings_to_try = ["utf-8", "latin-1"]
-        for encoding in encodings_to_try:
-            try:
-                with open(path, "r", encoding=encoding) as f:
-                    content = f.read()
-                self.formatter.write(path, content)
-                return
-            except UnicodeDecodeError:
-                continue
-            except Exception as e:
-                logger.warning(f"File read error {path}: {e}")
-                return
-        logger.warning(f"Could not read file {path} with provided encodings.")
-
-    def _handle_directory(self, directory: str, depth: int, extra_gitignore_rules: List[str]) -> None:
-        gitignore_handler = None
-        if not self.ignore_gitignore:
-            gitignore_handler = GitignoreHandler(directory)
-        for root, dirs, files in os.walk(directory):
-            if not self.include_hidden:
-                dirs[:] = [d for d in dirs if not d.startswith(".")]
-                files = [f for f in files if not f.startswith(".")]
-
-            if gitignore_handler:
-                dirs[:] = [d for d in dirs if not gitignore_handler.should_ignore(os.path.join(root, d))]
-                files = [f for f in files if not gitignore_handler.should_ignore(os.path.join(root, f))]
-
-            dirs[:] = [d for d in dirs if not should_ignore(os.path.join(root, d), extra_gitignore_rules)]
-            files = [f for f in files if not should_ignore(os.path.join(root, f), extra_gitignore_rules)]
-
-            if self.ignore_patterns:
-                files = [
-                    f for f in files
-                    if not any(fnmatch(f, pattern) for pattern in self.ignore_patterns)
-                ]
-
-            if self.extensions:
-                files = [
-                    f for f in files
-                    if any(f.lower().endswith(ext) for ext in self.extensions)
-                ]
-
-            for file_name in sorted(files):
-                self.process_path(os.path.join(root, file_name), depth + 1, extra_gitignore_rules)
-
-@click.command()
-@click.argument("paths", nargs=-1, type=click.Path(exists=True))
-@click.option("-e", "--extension", "extensions", multiple=True, help="Specify file extensions, e.g. .txt, .md.")
-@click.option("--include-hidden", is_flag=True, default=False, help="Include hidden files and subdirectories.")
-@click.option("--ignore-gitignore", is_flag=True, default=False, help="Do not apply .gitignore-based filtering.")
-@click.option("--ignore", "ignore_patterns", multiple=True, help="Specify one or more glob patterns to exclude.")
-@click.option("-o", "--output", "output_file", type=click.Path(writable=True), help="Output file path (stdout by default).")
-@click.option("--xml", "output_xml", is_flag=True, default=False, help="Output in XML-like format.")
-@click.option("-t", "--template-file", "template_file", type=click.Path(exists=True), help="Use a Jinja2 template for output.")
-@click.option("-d", "--max-depth", "max_depth", default=5, help="Maximum recursion depth for nested archives.")
-def cli(paths, extensions, include_hidden, ignore_gitignore, ignore_patterns, output_file, output_xml, template_file, max_depth):
-    """
-    "f2p" -- Enhanced from "framework1" using "raw_data":
-    1) Safe recursion-based file and archive handling.
-    2) Advanced ignoring logic from .gitignore or pathspec.
-    3) Optional Jinja2-based templating for output formatting.
-    """
-    writer = click.echo
-    file_handle = None
-
-    if output_file:
-        try:
-            file_handle = open(output_file, "w", encoding="utf-8")
-            writer = lambda msg: print(msg, file=file_handle)
-        except IOError as e:
-            logger.error(f"Could not open output file {output_file}: {e}")
-            sys.exit(1)
-
-    formatter = OutputFormatter(
-        writer=writer,
-        xml_mode=output_xml,
-        template_file=template_file
+function Test-IgnoredByRules {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string[]]$Rules
     )
 
-    if output_xml and not template_file:
-        writer("<root>")
+    if (-not $Rules -or $Rules.Count -eq 0) {
+        return $false
+    }
 
-    processor = FileProcessor(
-        extensions=extensions,
-        include_hidden=include_hidden,
-        ignore_gitignore=ignore_gitignore,
-        ignore_patterns=ignore_patterns,
-        formatter=formatter,
-        max_depth=max_depth
+    $leaf = Split-Path -Path $Path -Leaf
+    $isDirectory = Test-Path -LiteralPath $Path -PathType Container
+    if ($isDirectory) {
+        $leaf = "$leaf/"
+    }
+
+    foreach ($rule in $Rules) {
+        if ($leaf -like $rule -or $Path -like $rule) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Expand-ArchiveSafe {
+    param(
+        [Parameter(Mandatory)][string]$InputPath,
+        [Parameter(Mandatory)][string]$Destination
     )
 
-    for path in paths:
-        processor.process_path(path)
+    if (-not (Test-Path -LiteralPath $InputPath -PathType Leaf)) {
+        return $false
+    }
 
-    if output_xml and not template_file:
-        writer("</root>")
+    $ext = [IO.Path]::GetExtension($InputPath).ToLowerInvariant()
 
-    if file_handle:
-        file_handle.close()
+    try {
+        switch ($ext) {
+            '.zip' {
+                Expand-Archive -LiteralPath $InputPath -DestinationPath $Destination -Force
+                return $true
+            }
+            '.docx' { Expand-Archive -LiteralPath $InputPath -DestinationPath $Destination -Force; return $true }
+            '.xlsx' { Expand-Archive -LiteralPath $InputPath -DestinationPath $Destination -Force; return $true }
+            '.pptx' { Expand-Archive -LiteralPath $InputPath -DestinationPath $Destination -Force; return $true }
+            '.odt'  { Expand-Archive -LiteralPath $InputPath -DestinationPath $Destination -Force; return $true }
+            '.ods'  { Expand-Archive -LiteralPath $InputPath -DestinationPath $Destination -Force; return $true }
+            '.odp'  { Expand-Archive -LiteralPath $InputPath -DestinationPath $Destination -Force; return $true }
+            '.tar'  { tar -xf $InputPath -C $Destination; return $LASTEXITCODE -eq 0 }
+            '.gz'   { tar -xzf $InputPath -C $Destination; return $LASTEXITCODE -eq 0 }
+            '.bz2'  { tar -xjf $InputPath -C $Destination; return $LASTEXITCODE -eq 0 }
+            '.7z' {
+                if (Get-Command 7z -ErrorAction SilentlyContinue) {
+                    7z x "-o$Destination" $InputPath | Out-Null
+                    return $LASTEXITCODE -eq 0
+                }
+            }
+            '.rar' {
+                if (Get-Command unrar -ErrorAction SilentlyContinue) {
+                    unrar x -o+ $InputPath $Destination | Out-Null
+                    return $LASTEXITCODE -eq 0
+                }
+            }
+        }
+    } catch {
+        Write-Warning "Extraction failed for '$InputPath': $($_.Exception.Message)"
+        return $false
+    }
 
-if __name__ == "__main__":
-    cli()
+    Write-Warning "No extractor available for '$InputPath'."
+    return $false
+}
+
+function Format-Entry {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Content,
+        [Parameter(Mandatory)][ref]$Index,
+        [Parameter(Mandatory)][bool]$XmlMode,
+        [string]$Template
+    )
+
+    if ($Template) {
+        $rendered = $Template.Replace('{{ path }}', $Path).Replace('{{ content }}', $Content).Replace('{{ index }}', [string]$Index.Value)
+        $Index.Value++
+        return $rendered
+    }
+
+    if ($XmlMode) {
+        $escapedPath = [System.Security.SecurityElement]::Escape($Path)
+        $escapedContent = [System.Security.SecurityElement]::Escape($Content)
+        $Index.Value++
+        return "<section><source>$escapedPath</source><contents>$escapedContent</contents></section>"
+    }
+
+    $Index.Value++
+    return @(
+        $Path,
+        '--',
+        $Content,
+        '',
+        '--'
+    ) -join [Environment]::NewLine
+}
+
+function Invoke-FileRead {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $encodings = @('utf-8', 'latin1')
+    foreach ($encoding in $encodings) {
+        try {
+            return Get-Content -LiteralPath $Path -Raw -Encoding $encoding
+        } catch {
+            continue
+        }
+    }
+
+    Write-Warning "Could not read '$Path' using utf-8 or latin1."
+    return $null
+}
+
+function Invoke-PathProcessing {
+    param(
+        [Parameter(Mandatory)][string]$CurrentPath,
+        [int]$Depth = 0,
+        [string[]]$InheritedGitignore = @(),
+        [Parameter(Mandatory)][System.Collections.Generic.List[string]]$OutputChunks,
+        [Parameter(Mandatory)][ref]$Index,
+        [string]$TemplateContent
+    )
+
+    if ($Depth -gt $MaxDepth) {
+        Write-Warning "Max recursion depth ($MaxDepth) reached at '$CurrentPath'."
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath $CurrentPath)) {
+        Write-Warning "Path not found: '$CurrentPath'"
+        return
+    }
+
+    if (-not $IncludeHidden -and (Test-HiddenPath -Path $CurrentPath)) {
+        return
+    }
+
+    if ((Test-Path -LiteralPath $CurrentPath -PathType Leaf)) {
+        $ext = [IO.Path]::GetExtension($CurrentPath).ToLowerInvariant()
+
+        if (($script:ArchiveExtensions -contains $ext) -or ($script:OfficeExtensions -contains $ext)) {
+            $tempDir = Join-Path -Path ([IO.Path]::GetTempPath()) -ChildPath ("f4p_" + [guid]::NewGuid())
+            [void](New-Item -Path $tempDir -ItemType Directory -Force)
+
+            try {
+                if (Expand-ArchiveSafe -InputPath $CurrentPath -Destination $tempDir) {
+                    Invoke-PathProcessing -CurrentPath $tempDir -Depth ($Depth + 1) -InheritedGitignore @() -OutputChunks $OutputChunks -Index $Index -TemplateContent $TemplateContent
+                }
+            } finally {
+                Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+            return
+        }
+
+        if ($Extension.Count -gt 0 -and -not ($Extension | ForEach-Object { $_.ToLowerInvariant() } | Where-Object { $CurrentPath.ToLowerInvariant().EndsWith($_) })) {
+            return
+        }
+
+        if ($Ignore.Count -gt 0 -and ($Ignore | Where-Object { $CurrentPath -like $_ -or (Split-Path -Path $CurrentPath -Leaf) -like $_ })) {
+            return
+        }
+
+        $content = Invoke-FileRead -Path $CurrentPath
+        if ($null -ne $content) {
+            $OutputChunks.Add((Format-Entry -Path $CurrentPath -Content $content -Index $Index -XmlMode $Xml.IsPresent -Template $TemplateContent))
+        }
+        return
+    }
+
+    $localGitignore = @()
+    if (-not $IgnoreGitignore) {
+        $localGitignore = Get-GitignoreRules -Directory $CurrentPath
+    }
+    $allRules = @($InheritedGitignore + $localGitignore)
+
+    Get-ChildItem -LiteralPath $CurrentPath -Force | Sort-Object FullName | ForEach-Object {
+        $itemPath = $_.FullName
+
+        if (-not $IncludeHidden -and (Test-HiddenPath -Path $itemPath)) {
+            return
+        }
+
+        if (-not $IgnoreGitignore -and (Test-IgnoredByRules -Path $itemPath -Rules $allRules)) {
+            return
+        }
+
+        if ($Ignore.Count -gt 0 -and ($Ignore | Where-Object { $itemPath -like $_ -or (Split-Path -Path $itemPath -Leaf) -like $_ })) {
+            return
+        }
+
+        Invoke-PathProcessing -CurrentPath $itemPath -Depth ($Depth + 1) -InheritedGitignore $allRules -OutputChunks $OutputChunks -Index $Index -TemplateContent $TemplateContent
+    }
+}
+
+$templateContent = $null
+if ($TemplateFile) {
+    if (-not (Test-Path -LiteralPath $TemplateFile -PathType Leaf)) {
+        throw "Template file not found: $TemplateFile"
+    }
+    $templateContent = Get-Content -LiteralPath $TemplateFile -Raw
+}
+
+$outputChunks = New-Object 'System.Collections.Generic.List[string]'
+$index = 1
+
+foreach ($p in $Paths) {
+    Invoke-PathProcessing -CurrentPath (Resolve-Path -LiteralPath $p).Path -Depth 0 -InheritedGitignore @() -OutputChunks $outputChunks -Index ([ref]$index) -TemplateContent $templateContent
+}
+
+$result = if ($Xml) {
+    "<root>$([Environment]::NewLine)$($outputChunks -join [Environment]::NewLine)$([Environment]::NewLine)</root>"
+} else {
+    $outputChunks -join [Environment]::NewLine
+}
+
+if ($Output) {
+    Set-Content -LiteralPath $Output -Value $result -Encoding utf8
+} else {
+    $result
+}
 ```
 {% endraw %}

--- a/_posts/2025-02-05-f4p.md
+++ b/_posts/2025-02-05-f4p.md
@@ -418,7 +418,7 @@ function Invoke-PathProcessing {
             return
         }
 
-        if ($Extension.Count -gt 0 -and -not ($Extension | ForEach-Object { $_.ToLowerInvariant() } | Where-Object { $CurrentPath.ToLowerInvariant().EndsWith($_) })) {
+        if ($Extension.Count -gt 0 -and -not ($Extension.Where({ $CurrentPath.EndsWith($_, 'OrdinalIgnoreCase') }, 'First'))) {
             return
         }
 


### PR DESCRIPTION
### Motivation

- Replace the original Python implementation and documentation with a native PowerShell implementation to better support Windows/PowerShell workflows and external extractors.
- Simplify templating by removing Jinja2 dependency and using literal token replacement for templates to avoid introducing a heavy templating runtime.
- Use platform-native extraction tools (`7z`, `unrar`, `tar`, `Expand-Archive`) and PowerShell file APIs to handle archives and Office documents safely.

### Description

- Converted the usage docs and examples from Python to PowerShell, replacing references to `f4p.py` with `f4p.ps1` and switching CLI flags to PowerShell-style parameters like `-Extension`, `-IncludeHidden`, `-Xml`, `-TemplateFile`, and `-MaxDepth`.
- Replaced the Python code block with a full PowerShell script implementing `Test-HiddenPath`, `Get-GitignoreRules`, `Test-IgnoredByRules`, `Expand-ArchiveSafe`, `Format-Entry`, `Invoke-FileRead`, and `Invoke-PathProcessing` to recursively scan, extract, read, and format file contents.
- Switched archive extraction to rely on `Expand-Archive`, `tar`, `7z`, and `unrar` when available and added safe extraction and temporary-directory handling for nested archives; Office OOXML/ODF files are treated as ZIP archives.
- Replaced Jinja2 templating with literal token replacement (`{{ path }}`, `{{ content }}`, `{{ index }}`) and documented example token-based templates, while explicitly noting that Jinja logic/filters are not executed.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc23db1c08832a8d49780632042726)

## Summary by Sourcery

Port the f4p utility and its documentation from a Python-based CLI to a standalone PowerShell script with PowerShell-style parameters and native archive handling.

New Features:
- Introduce a self-contained PowerShell implementation of the f4p script that recursively scans paths, safely expands archives and Office documents, and aggregates file contents.
- Add token-based templating support in PowerShell using literal placeholders for path, content, and index, alongside an XML-like output mode.

Enhancements:
- Update user-facing documentation to describe PowerShell 7+ usage, parameters, prerequisites, and examples instead of the previous Python/click interface.
- Switch archive handling to rely on platform-native tools and PowerShell cmdlets, with temporary-directory extraction and depth limiting for nested archives.
- Replace .gitignore handling with a pragmatic wildcard-based matcher implemented in PowerShell, and align ignore/hidden-file behavior with the new environment.

Documentation:
- Revise the f4p blog post to document PowerShell installation, usage, CLI options, file-handling behavior, and token-based template examples targeting PowerShell users.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports `f4p` from Python to a standalone PowerShell script (`f4p.ps1`), removes Python deps, and updates docs to token-only templating with minimal examples. Latest changes fix recursion depth handling, improve case-insensitive matching, and align docs to `-MaxDepth`.

- **Bug Fixes**
  - Correct recursion depth handling when traversing directories.
  - Case-insensitive extension filtering via `EndsWith(..., 'OrdinalIgnoreCase')` and `$Extension.Where(...)`.
  - Faster ignore checks using `$Ignore.Where(...)` and `$itemName` matching.
  - Docs: replace `--max-depth` with `-MaxDepth`, simplify templates to valid token examples, and state that Jinja `{% ... %}` is not executed.

- **Migration**
  - Run with `pwsh ./f4p.ps1 ...` instead of `python f4p.py ...`.
  - Update templates to token-only text: `{{ path }}`, `{{ content }}`, `{{ index }}`.
  - Install optional tools if needed: `7z` for `.7z`, `unrar` for `.rar`; `tar` recommended on non-Windows.

<sup>Written for commit e804e05976cf348d92e47cf70ea38e5f810906a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

